### PR TITLE
Fix sync timeout gets overridden with default value every time

### DIFF
--- a/lib/matrix_sdk/protocols/cs.rb
+++ b/lib/matrix_sdk/protocols/cs.rb
@@ -41,13 +41,11 @@ module MatrixSdk::Protocols::CS
   # @see https://matrix.org/docs/spec/client_server/r0.3.0.html#get-matrix-client-r0-sync
   #      For more information on the parameters and what they mean
   def sync(timeout: 30.0, **params)
-    query = {
-      timeout: timeout
-    }.merge(params).select do |k, _v|
+    query = params.select do |k, _v|
       %i[since filter full_state set_presence].include? k
     end
 
-    query[:timeout] = (query.fetch(:timeout, 30) * 1000).to_i
+    query[:timeout] = (timeout * 1000).to_i
     query[:timeout] = params.delete(:timeout_ms).to_i if params.key? :timeout_ms
     query[:user_id] = params.delete(:user_id) if protocol?(:AS) && params.key?(:user_id)
 


### PR DESCRIPTION
This should fix the bug in CS protocol where sync timeout was always overridden with default value. I wanted to add spec as well, but currently not sure I understand how to do these. Maybe I'll update the PR.

As extra payload, which you can overrule simply, is timeout default value. I set it as 0 as in CS protocol states. I think this should be good practice to have these defaults as in spec. But I don't know your argumentation why this 30 was used in first place.