### PR TITLE
Don't crash from a to_sym undefined error when the state_event's cont…

### DIFF
--- a/lib/matrix_sdk/client.rb
+++ b/lib/matrix_sdk/client.rb
@@ -574,9 +574,9 @@ module MatrixSdk
       when 'm.room.aliases'
         room.instance_variable_get('@aliases').concat content[:aliases]
       when 'm.room.join_rules'
-        room.instance_variable_set '@join_rule', content[:join_rule].to_s.to_sym
+        room.instance_variable_set '@join_rule', content[:join_rule].nil? ? nil : content[:join_rule].to_sym
       when 'm.room.guest_access'
-        room.instance_variable_set '@guest_access', content[:guest_access].to_s.to_sym
+        room.instance_variable_set '@guest_access', content[:guest_access].nil? ? nil : content[:guest_access].to_sym
       when 'm.room.member'
         return unless cache == :all
 

--- a/lib/matrix_sdk/client.rb
+++ b/lib/matrix_sdk/client.rb
@@ -574,9 +574,9 @@ module MatrixSdk
       when 'm.room.aliases'
         room.instance_variable_get('@aliases').concat content[:aliases]
       when 'm.room.join_rules'
-        room.instance_variable_set '@join_rule', content[:join_rule].to_sym
+        room.instance_variable_set '@join_rule', content[:join_rule].to_s.to_sym
       when 'm.room.guest_access'
-        room.instance_variable_set '@guest_access', content[:guest_access].to_sym
+        room.instance_variable_set '@guest_access', content[:guest_access].to_s.to_sym
       when 'm.room.member'
         return unless cache == :all
 


### PR DESCRIPTION
…ent is null

When I try to use this, it throws this error:

```
/home/xxxx/.rvm/gems/ruby-2.7.1@yyyy/gems/matrix_sdk-2.1.0/lib/matrix_sdk/client.rb:579:in `handle_state': undefined method `to_sym' for nil:NilClass (NoMethodError)
```

When I ran this locally and used a `puts` statement to see what was going on in the `state_event`. The Matrix server I was connecting to was returning an `m.room.guest_access` event with no content, thus causing the crash. While this field of `guest_access` is definitely [listed as required](https://github.com/matrix-org/matrix-doc/blob/master/event-schemas/schema/m.room.guest_access) in the spec, that apparently doesn't always happen in reality.

Converting `nil` to the empty string, and from there into the symbol (`:""`), I think would make a valuable addition to this project because it makes it more robust against erroneous server responses.