### PR TITLE
NEW: Add CS Protocol /r0/rooms/{roomId}/context/{eventId}

### DIFF
--- a/lib/matrix_sdk/protocols/cs.rb
+++ b/lib/matrix_sdk/protocols/cs.rb
@@ -771,12 +771,17 @@ module MatrixSdk::Protocols::CS
   #
   # @param room_id [MXID,String] The room to get events from.
   # @param event_id [String] The event to get context around.
+  # @param limit [Integer] (10) The limit of messages to retrieve
+  # @option params [String] :filter A filter to limit the retrieval to
   # @return [Response] A response hash with contextual event information
   # @see https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-rooms-roomid-context-eventid
   #      The Matrix Spec, for more information about the call and response
   def get_room_event_context(room_id, event_id, **params)
     query = {}
     query[:user_id] = params.delete(:user_id) if protocol?(:AS) && params.key?(:user_id)
+
+    query[:limit] = params.fetch(:limit) if params.key? :limit
+    query[:filter] = params.fetch(:filter) if params.key? :filter
 
     room_id = ERB::Util.url_encode room_id.to_s
     event_id = ERB::Util.url_encode event_id.to_s

--- a/lib/matrix_sdk/protocols/cs.rb
+++ b/lib/matrix_sdk/protocols/cs.rb
@@ -767,6 +767,23 @@ module MatrixSdk::Protocols::CS
     request(:get, :client_r0, "/rooms/#{room_id}/state", query: query)
   end
 
+  # Retrieves number of events that happened just before and after the specified event
+  #
+  # @param room_id [MXID,String] The room to get events from.
+  # @param event_id [String] The event to get context around.
+  # @return [Response] A response hash with contextual event information
+  # @see https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-rooms-roomid-context-eventid
+  #      The Matrix Spec, for more information about the call and response
+  def get_room_event_context(room_id, event_id, **params)
+    query = {}
+    query[:user_id] = params.delete(:user_id) if protocol?(:AS) && params.key?(:user_id)
+
+    room_id = ERB::Util.url_encode room_id.to_s
+    event_id = ERB::Util.url_encode event_id.to_s
+
+    request(:get, :client_r0, "/rooms/#{room_id}/context/#{event_id}", query: query)
+  end
+
   ## Specialized getters for specced state
   #
 

--- a/lib/matrix_sdk/protocols/cs.rb
+++ b/lib/matrix_sdk/protocols/cs.rb
@@ -771,7 +771,7 @@ module MatrixSdk::Protocols::CS
   #
   # @param room_id [MXID,String] The room to get events from.
   # @param event_id [MXID,String] The event to get context around.
-  # @option limit [Integer] (10) The limit of messages to retrieve
+  # @option params [Integer] :limit (10) The limit of messages to retrieve
   # @option params [String] :filter A filter to limit the retrieval to
   # @return [Response] A response hash with contextual event information
   # @see https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-rooms-roomid-context-eventid

--- a/lib/matrix_sdk/protocols/cs.rb
+++ b/lib/matrix_sdk/protocols/cs.rb
@@ -770,12 +770,14 @@ module MatrixSdk::Protocols::CS
   # Retrieves number of events that happened just before and after the specified event
   #
   # @param room_id [MXID,String] The room to get events from.
-  # @param event_id [String] The event to get context around.
-  # @param limit [Integer] (10) The limit of messages to retrieve
+  # @param event_id [MXID,String] The event to get context around.
+  # @option limit [Integer] (10) The limit of messages to retrieve
   # @option params [String] :filter A filter to limit the retrieval to
   # @return [Response] A response hash with contextual event information
   # @see https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-rooms-roomid-context-eventid
   #      The Matrix Spec, for more information about the call and response
+  # @example Find event context with filter and limit specified
+  #   api.get_room_event_context('##room_id##', '##event_id##', filter: { types: ['m.room.message'] }.to_json, limit: 20)
   def get_room_event_context(room_id, event_id, **params)
     query = {}
     query[:user_id] = params.delete(:user_id) if protocol?(:AS) && params.key?(:user_id)

--- a/lib/matrix_sdk/protocols/cs.rb
+++ b/lib/matrix_sdk/protocols/cs.rb
@@ -777,7 +777,7 @@ module MatrixSdk::Protocols::CS
   # @see https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-rooms-roomid-context-eventid
   #      The Matrix Spec, for more information about the call and response
   # @example Find event context with filter and limit specified
-  #   api.get_room_event_context('##room_id##', '##event_id##', filter: { types: ['m.room.message'] }.to_json, limit: 20)
+  #   api.get_room_event_context('#room:example.com', '$event_id:example.com', filter: { types: ['m.room.message'] }.to_json, limit: 20)
   def get_room_event_context(room_id, event_id, **params)
     query = {}
     query[:user_id] = params.delete(:user_id) if protocol?(:AS) && params.key?(:user_id)


### PR DESCRIPTION
Adds support for a missing api method from the CS protocol 
https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-rooms-roomid-context-eventid