### PR TITLE
Remove deprecation warnings for Ruby 2.7 and actually support Ruby 3

### DIFF
--- a/lib/matrix_sdk/api.rb
+++ b/lib/matrix_sdk/api.rb
@@ -163,11 +163,13 @@ module MatrixSdk
 
       params[:well_known] = well_known if keep_wellknown
 
-      new(uri,
-          params.merge(
-            address: target_uri.host,
-            port: target_uri.port
-          ))
+      new(
+        uri,
+        **params.merge(
+          address: target_uri.host,
+          port: target_uri.port
+        )
+      )
     end
 
     # Get a list of enabled protocols on the API client

--- a/lib/matrix_sdk/client.rb
+++ b/lib/matrix_sdk/client.rb
@@ -67,7 +67,7 @@ module MatrixSdk
           api.instance_variable_set("@#{k}", v) if api.instance_variable_defined? "@#{k}"
         end
       else
-        @api = Api.new hs_url, params
+        @api = Api.new hs_url, **params
       end
 
       @cache = client_cache
@@ -469,7 +469,7 @@ module MatrixSdk
 
         @should_listen = cancel_token
       else
-        thread = Thread.new { listen_forever(params) }
+        thread = Thread.new { listen_forever(**params) }
       end
       @sync_thread = thread
       thread.run

--- a/lib/matrix_sdk/protocols/cs.rb
+++ b/lib/matrix_sdk/protocols/cs.rb
@@ -584,7 +584,7 @@ module MatrixSdk::Protocols::CS
     }
     content.merge!(params.fetch(:extra_content)) if params.key? :extra_content
 
-    send_message_event(room_id, 'm.room.message', content, params)
+    send_message_event(room_id, 'm.room.message', content, **params)
   end
 
   # Send a geographic location to a room
@@ -610,7 +610,7 @@ module MatrixSdk::Protocols::CS
     content[:info][:thumbnail_url] = params.delete(:thumbnail_url) if params.key? :thumbnail_url
     content[:info][:thumbnail_info] = params.delete(:thumbnail_info) if params.key? :thumbnail_info
 
-    send_message_event(room_id, 'm.room.message', content, params)
+    send_message_event(room_id, 'm.room.message', content, **params)
   end
 
   # Send a plaintext message to a room
@@ -628,7 +628,7 @@ module MatrixSdk::Protocols::CS
       msgtype: params.delete(:msg_type) { 'm.text' },
       body: message
     }
-    send_message_event(room_id, 'm.room.message', content, params)
+    send_message_event(room_id, 'm.room.message', content, **params)
   end
 
   # Send a plaintext emote to a room
@@ -646,7 +646,7 @@ module MatrixSdk::Protocols::CS
       msgtype: params.delete(:msg_type) { 'm.emote' },
       body: emote
     }
-    send_message_event(room_id, 'm.room.message', content, params)
+    send_message_event(room_id, 'm.room.message', content, **params)
   end
 
   # Send a plaintext notice to a room
@@ -664,7 +664,7 @@ module MatrixSdk::Protocols::CS
       msgtype: params.delete(:msg_type) { 'm.notice' },
       body: notice
     }
-    send_message_event(room_id, 'm.room.message', content, params)
+    send_message_event(room_id, 'm.room.message', content, **params)
   end
 
   # Report an event in a room
@@ -804,7 +804,7 @@ module MatrixSdk::Protocols::CS
   # @see https://matrix.org/docs/spec/client_server/latest.html#m-room-name
   #      The Matrix Spec, for more information about the event and data
   def get_room_name(room_id, **params)
-    get_room_state(room_id, 'm.room.name', params)
+    get_room_state(room_id, 'm.room.name', **params)
   end
 
   # Sets the display name of a room
@@ -819,7 +819,7 @@ module MatrixSdk::Protocols::CS
     content = {
       name: name
     }
-    send_state_event(room_id, 'm.room.name', content, params)
+    send_state_event(room_id, 'm.room.name', content, **params)
   end
 
   # Gets the current topic of a room
@@ -832,7 +832,7 @@ module MatrixSdk::Protocols::CS
   # @see https://matrix.org/docs/spec/client_server/latest.html#m-room-topic
   #      The Matrix Spec, for more information about the event and data
   def get_room_topic(room_id, **params)
-    get_room_state(room_id, 'm.room.topic', params)
+    get_room_state(room_id, 'm.room.topic', **params)
   end
 
   # Sets the topic of a room
@@ -847,7 +847,7 @@ module MatrixSdk::Protocols::CS
     content = {
       topic: topic
     }
-    send_state_event(room_id, 'm.room.topic', content, params)
+    send_state_event(room_id, 'm.room.topic', content, **params)
   end
 
   # Gets the current avatar URL of a room
@@ -860,7 +860,7 @@ module MatrixSdk::Protocols::CS
   # @see https://matrix.org/docs/spec/client_server/latest.html#m-room-avatar
   #      The Matrix Spec, for more information about the event and data
   def get_room_avatar(room_id, **params)
-    get_room_state(room_id, 'm.room.avatar', params)
+    get_room_state(room_id, 'm.room.avatar', **params)
   end
 
   # Sets the avatar URL for a room
@@ -875,7 +875,7 @@ module MatrixSdk::Protocols::CS
     content = {
       url: url
     }
-    send_state_event(room_id, 'm.room.avatar', content, params)
+    send_state_event(room_id, 'm.room.avatar', content, **params)
   end
 
   # Gets a list of current aliases of a room
@@ -902,7 +902,7 @@ module MatrixSdk::Protocols::CS
   #      .compact
   #   # => ["#synapse:im.kabi.tk", "#synapse:matrix.org", "#synapse-community:matrix.org", "#synapse-ops:matrix.org", "#synops:matrix.org", ...
   def get_room_aliases(room_id, **params)
-    get_room_state(room_id, 'm.room.aliases', params)
+    get_room_state(room_id, 'm.room.aliases', params) # :FIXME: missing spec
   end
 
   # Gets a list of pinned events in a room
@@ -915,7 +915,7 @@ module MatrixSdk::Protocols::CS
   # @see https://matrix.org/docs/spec/client_server/latest.html#m-room-pinned-events
   #      The Matrix Spec, for more information about the event and data
   def get_room_pinned_events(room_id, **params)
-    get_room_state(room_id, 'm.room.pinned_events', params)
+    get_room_state(room_id, 'm.room.pinned_events', **params)
   end
 
   # Sets the list of pinned events in a room
@@ -930,7 +930,7 @@ module MatrixSdk::Protocols::CS
     content = {
       pinned: events
     }
-    send_state_event(room_id, 'm.room.pinned_events', content, params)
+    send_state_event(room_id, 'm.room.pinned_events', content, **params)
   end
 
   # Gets the configured power levels for a room
@@ -942,7 +942,7 @@ module MatrixSdk::Protocols::CS
   # @see https://matrix.org/docs/spec/client_server/latest.html#m-room-power-levels
   #      The Matrix Spec, for more information about the event and data
   def get_room_power_levels(room_id, **params)
-    get_room_state(room_id, 'm.room.power_levels', params)
+    get_room_state(room_id, 'm.room.power_levels', **params)
   end
   alias get_power_levels get_room_power_levels
 
@@ -956,7 +956,7 @@ module MatrixSdk::Protocols::CS
   #      The Matrix Spec, for more information about the event and data
   def set_room_power_levels(room_id, content, **params)
     content[:events] = {} unless content.key? :events
-    send_state_event(room_id, 'm.room.power_levels', content, params)
+    send_state_event(room_id, 'm.room.power_levels', content, **params)
   end
   alias set_power_levels set_room_power_levels
 
@@ -969,7 +969,7 @@ module MatrixSdk::Protocols::CS
   # @see https://matrix.org/docs/spec/client_server/latest.html#m-room-join-rules
   #      The Matrix Spec, for more information about the event and data
   def get_room_join_rules(room_id, **params)
-    get_room_state(room_id, 'm.room.join_rules', params)
+    get_room_state(room_id, 'm.room.join_rules', **params)
   end
 
   # Sets the join rules for a room
@@ -985,7 +985,7 @@ module MatrixSdk::Protocols::CS
       join_rule: join_rule
     }
 
-    send_state_event(room_id, 'm.room.join_rules', content, params)
+    send_state_event(room_id, 'm.room.join_rules', content, **params)
   end
 
   # Gets the guest access settings for a room
@@ -997,7 +997,7 @@ module MatrixSdk::Protocols::CS
   # @see https://matrix.org/docs/spec/client_server/latest.html#m-room-guest-access
   #      The Matrix Spec, for more information about the event and data
   def get_room_guest_access(room_id, **params)
-    get_room_state(room_id, 'm.room.guest_access', params)
+    get_room_state(room_id, 'm.room.guest_access', **params)
   end
 
   # Sets the guest access settings for a room
@@ -1013,7 +1013,7 @@ module MatrixSdk::Protocols::CS
       guest_access: guest_access
     }
 
-    send_state_event(room_id, 'm.room.guest_access', content, params)
+    send_state_event(room_id, 'm.room.guest_access', content, **params)
   end
 
   # Gets the creation configuration object for a room
@@ -1025,7 +1025,7 @@ module MatrixSdk::Protocols::CS
   # @see https://matrix.org/docs/spec/client_server/latest.html#m-room-create
   #      The Matrix Spec, for more information about the event and data
   def get_room_creation_info(room_id, **params)
-    get_room_state(room_id, 'm.room.create', params)
+    get_room_state(room_id, 'm.room.create', **params)
   end
 
   # Gets the encryption configuration for a room
@@ -1037,7 +1037,7 @@ module MatrixSdk::Protocols::CS
   # @see https://matrix.org/docs/spec/client_server/latest.html#m-room-encryption
   #      The Matrix Spec, for more information about the event and data
   def get_room_encryption_settings(room_id, **params)
-    get_room_state(room_id, 'm.room.encryption', params)
+    get_room_state(room_id, 'm.room.encryption', **params)
   end
 
   # Sets the encryption configuration for a room
@@ -1056,7 +1056,7 @@ module MatrixSdk::Protocols::CS
       rotation_period_ms: rotation_period_ms,
       rotation_period_msgs: rotation_period_msgs
     }
-    send_state_event(room_id, 'm.room.encryption', content, params)
+    send_state_event(room_id, 'm.room.encryption', content, **params)
   end
 
   # Gets the history availabiilty for a room
@@ -1068,7 +1068,7 @@ module MatrixSdk::Protocols::CS
   # @see https://matrix.org/docs/spec/client_server/latest.html#m-room-history-visibility
   #      The Matrix Spec, for more information about the event and data
   def get_room_history_visibility(room_id, **params)
-    get_room_state(room_id, 'm.room.history_visibility', params)
+    get_room_state(room_id, 'm.room.history_visibility', **params)
   end
 
   # Sets the history availability for a room
@@ -1084,7 +1084,7 @@ module MatrixSdk::Protocols::CS
       history_visibility: visibility
     }
 
-    send_state_event(room_id, 'm.room.history_visibility', content, params)
+    send_state_event(room_id, 'm.room.history_visibility', content, **params)
   end
 
   # Gets the server ACLs for a room
@@ -1096,7 +1096,7 @@ module MatrixSdk::Protocols::CS
   # @see https://matrix.org/docs/spec/client_server/latest.html#m-room-server-acl
   #      The Matrix Spec, for more information about the event and data
   def get_room_server_acl(room_id, **params)
-    get_room_state(room_id, 'm.room.server_acl', params)
+    get_room_state(room_id, 'm.room.server_acl', **params)
   end
 
   # Sets the server ACL configuration for a room
@@ -1116,7 +1116,7 @@ module MatrixSdk::Protocols::CS
       deny: deny
     }
 
-    send_state_event(room_id, 'm.room.server_acl', content, params)
+    send_state_event(room_id, 'm.room.server_acl', content, **params)
   end
 
   def leave_room(room_id, **params)

--- a/lib/matrix_sdk/protocols/cs.rb
+++ b/lib/matrix_sdk/protocols/cs.rb
@@ -902,7 +902,7 @@ module MatrixSdk::Protocols::CS
   #      .compact
   #   # => ["#synapse:im.kabi.tk", "#synapse:matrix.org", "#synapse-community:matrix.org", "#synapse-ops:matrix.org", "#synops:matrix.org", ...
   def get_room_aliases(room_id, **params)
-    get_room_state(room_id, 'm.room.aliases', params) # :FIXME: missing spec
+    get_room_state(room_id, 'm.room.aliases', **params)
   end
 
   # Gets a list of pinned events in a room

--- a/lib/matrix_sdk/room.rb
+++ b/lib/matrix_sdk/room.rb
@@ -481,7 +481,7 @@ module MatrixSdk
           @room
         end
         tag_obj.define_singleton_method(:add) do |tag, **data|
-          @room.add_tag(tag.to_s.to_sym, data)
+          @room.add_tag(tag.to_s.to_sym, **data)
           self[tag.to_s.to_sym] = data
           self
         end

--- a/test/api_cs_protocol_test.rb
+++ b/test/api_cs_protocol_test.rb
@@ -98,7 +98,7 @@ class ApiTest < Test::Unit::TestCase
       info: {}
     }
 
-    @api.expects(:send_message_event).with(room, type, content)
+    expect_message(@api, :send_message_event, room, type, content)
     @api.send_content(room, url, msgbody, msgtype)
 
     msgtype.replace 'm.location'
@@ -107,7 +107,7 @@ class ApiTest < Test::Unit::TestCase
     content.delete :url
     content[:geo_uri] = url
 
-    @api.expects(:send_message_event).with(room, type, content)
+    expect_message(@api, :send_message_event, room, type, content)
     @api.send_location(room, url, msgbody)
 
     content = {
@@ -117,87 +117,87 @@ class ApiTest < Test::Unit::TestCase
 
     msgtype.replace 'm.text'
 
-    @api.expects(:send_message_event).with(room, type, content)
+    expect_message(@api, :send_message_event, room, type, content)
     @api.send_message(room, msgbody)
 
     msgtype.replace 'm.emote'
 
-    @api.expects(:send_message_event).with(room, type, content)
+    expect_message(@api, :send_message_event, room, type, content)
     @api.send_emote(room, msgbody)
 
     msgtype.replace 'm.notice'
 
-    @api.expects(:send_message_event).with(room, type, content)
+    expect_message(@api, :send_message_event, room, type, content)
     @api.send_notice(room, msgbody)
   end
 
   def test_specced_state
     id = '!room:example.com'
 
-    @api.expects(:get_room_state).with(id, 'm.room.name')
+    expect_message(@api, :get_room_state, id, 'm.room.name')
     @api.get_room_name(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.name', { name: 'Room name' })
+    expect_message(@api, :send_state_event, id, 'm.room.name', { name: 'Room name' })
     @api.set_room_name(id, 'Room name')
 
-    @api.expects(:get_room_state).with(id, 'm.room.topic')
+    expect_message(@api, :get_room_state, id, 'm.room.topic')
     @api.get_room_topic(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.topic', { topic: 'Room topic' })
+    expect_message(@api, :send_state_event, id, 'm.room.topic', { topic: 'Room topic' })
     @api.set_room_topic(id, 'Room topic')
 
-    @api.expects(:get_room_state).with(id, 'm.room.avatar')
+    expect_message(@api, :get_room_state, id, 'm.room.avatar')
     @api.get_room_avatar(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.avatar', { url: 'Room avatar' })
+    expect_message(@api, :send_state_event, id, 'm.room.avatar', { url: 'Room avatar' })
     @api.set_room_avatar(id, 'Room avatar')
 
-    @api.expects(:get_room_state).with(id, 'm.room.aliases')
+    expect_message(@api, :get_room_state, id, 'm.room.aliases')
     @api.get_room_aliases(id)
 
-    @api.expects(:get_room_state).with(id, 'm.room.pinned_events')
+    expect_message(@api, :get_room_state, id, 'm.room.pinned_events')
     @api.get_room_pinned_events(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.pinned_events', { pinned: ['event'] })
+    expect_message(@api, :send_state_event, id, 'm.room.pinned_events', { pinned: ['event'] })
     @api.set_room_pinned_events(id, ['event'])
 
-    @api.expects(:get_room_state).with(id, 'm.room.power_levels')
+    expect_message(@api, :get_room_state, id, 'm.room.power_levels')
     @api.get_room_power_levels(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.power_levels', { level: 1, events: {} })
+    expect_message(@api, :send_state_event, id, 'm.room.power_levels', { level: 1, events: {} })
     @api.set_room_power_levels(id, level: 1)
 
-    @api.expects(:get_room_state).with(id, 'm.room.join_rules')
+    expect_message(@api, :get_room_state, id, 'm.room.join_rules')
     @api.get_room_join_rules(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.join_rules', { join_rule: :public })
+    expect_message(@api, :send_state_event, id, 'm.room.join_rules', { join_rule: :public })
     @api.set_room_join_rules(id, :public)
 
-    @api.expects(:get_room_state).with(id, 'm.room.guest_access')
+    expect_message(@api, :get_room_state, id, 'm.room.guest_access')
     @api.get_room_guest_access(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.guest_access', { guest_access: :forbidden })
+    expect_message(@api, :send_state_event, id, 'm.room.guest_access', { guest_access: :forbidden })
     @api.set_room_guest_access(id, :forbidden)
 
-    @api.expects(:get_room_state).with(id, 'm.room.create')
+    expect_message(@api, :get_room_state, id, 'm.room.create')
     @api.get_room_creation_info(id)
 
-    @api.expects(:get_room_state).with(id, 'm.room.encryption')
+    expect_message(@api, :get_room_state, id, 'm.room.encryption')
     @api.get_room_encryption_settings(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.encryption', { algorithm: 'm.megolm.v1.aes-sha2', rotation_period_ms: 604_800_000, rotation_period_msgs: 100 })
+    expect_message(@api, :send_state_event, id, 'm.room.encryption', { algorithm: 'm.megolm.v1.aes-sha2', rotation_period_ms: 604_800_000, rotation_period_msgs: 100 })
     @api.set_room_encryption_settings(id)
 
-    @api.expects(:get_room_state).with(id, 'm.room.history_visibility')
+    expect_message(@api, :get_room_state, id, 'm.room.history_visibility')
     @api.get_room_history_visibility(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.history_visibility', { history_visibility: :anyone })
+    expect_message(@api, :send_state_event, id, 'm.room.history_visibility', { history_visibility: :anyone })
     @api.set_room_history_visibility(id, :anyone)
 
-    @api.expects(:get_room_state).with(id, 'm.room.server_acl')
+    expect_message(@api, :get_room_state, id, 'm.room.server_acl')
     @api.get_room_server_acl(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.server_acl', { allow_ip_literals: false, allow: [], deny: [] })
+    expect_message(@api, :send_state_event, id, 'm.room.server_acl', { allow_ip_literals: false, allow: [], deny: [] })
     @api.set_room_server_acl(id, allow: [], deny: [])
   end
 

--- a/test/api_cs_protocol_test.rb
+++ b/test/api_cs_protocol_test.rb
@@ -199,7 +199,7 @@ class ApiTest < Test::Unit::TestCase
   end
 
   def test_download_url
-    assert_equal 'https://example.com/_matrix/media/r0/download/example.com/media',  @api.get_download_url('mxc://example.com/media').to_s
-    assert_equal 'https://matrix.org/_matrix/media/r0/download/example.com/media',  @api.get_download_url('mxc://example.com/media', source: 'matrix.org').to_s
+    assert_equal 'https://example.com/_matrix/media/r0/download/example.com/media', @api.get_download_url('mxc://example.com/media').to_s
+    assert_equal 'https://matrix.org/_matrix/media/r0/download/example.com/media', @api.get_download_url('mxc://example.com/media', source: 'matrix.org').to_s
   end
 end

--- a/test/api_cs_protocol_test.rb
+++ b/test/api_cs_protocol_test.rb
@@ -98,7 +98,7 @@ class ApiTest < Test::Unit::TestCase
       info: {}
     }
 
-    @api.expects(:send_message_event).with(room, type, content, {})
+    @api.expects(:send_message_event).with(room, type, content)
     @api.send_content(room, url, msgbody, msgtype)
 
     msgtype.replace 'm.location'
@@ -107,7 +107,7 @@ class ApiTest < Test::Unit::TestCase
     content.delete :url
     content[:geo_uri] = url
 
-    @api.expects(:send_message_event).with(room, type, content, {})
+    @api.expects(:send_message_event).with(room, type, content)
     @api.send_location(room, url, msgbody)
 
     content = {
@@ -117,84 +117,84 @@ class ApiTest < Test::Unit::TestCase
 
     msgtype.replace 'm.text'
 
-    @api.expects(:send_message_event).with(room, type, content, {})
+    @api.expects(:send_message_event).with(room, type, content)
     @api.send_message(room, msgbody)
 
     msgtype.replace 'm.emote'
 
-    @api.expects(:send_message_event).with(room, type, content, {})
+    @api.expects(:send_message_event).with(room, type, content)
     @api.send_emote(room, msgbody)
 
     msgtype.replace 'm.notice'
 
-    @api.expects(:send_message_event).with(room, type, content, {})
+    @api.expects(:send_message_event).with(room, type, content)
     @api.send_notice(room, msgbody)
   end
 
   def test_specced_state
     id = '!room:example.com'
 
-    @api.expects(:get_room_state).with(id, 'm.room.name', {})
+    @api.expects(:get_room_state).with(id, 'm.room.name')
     @api.get_room_name(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.name', { name: 'Room name' }, {})
+    @api.expects(:send_state_event).with(id, 'm.room.name', { name: 'Room name' })
     @api.set_room_name(id, 'Room name')
 
-    @api.expects(:get_room_state).with(id, 'm.room.topic', {})
+    @api.expects(:get_room_state).with(id, 'm.room.topic')
     @api.get_room_topic(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.topic', { topic: 'Room topic' }, {})
+    @api.expects(:send_state_event).with(id, 'm.room.topic', { topic: 'Room topic' })
     @api.set_room_topic(id, 'Room topic')
 
-    @api.expects(:get_room_state).with(id, 'm.room.avatar', {})
+    @api.expects(:get_room_state).with(id, 'm.room.avatar')
     @api.get_room_avatar(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.avatar', { url: 'Room avatar' }, {})
+    @api.expects(:send_state_event).with(id, 'm.room.avatar', { url: 'Room avatar' })
     @api.set_room_avatar(id, 'Room avatar')
 
-    @api.expects(:get_room_state).with(id, 'm.room.pinned_events', {})
+    @api.expects(:get_room_state).with(id, 'm.room.pinned_events')
     @api.get_room_pinned_events(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.pinned_events', { pinned: ['event'] }, {})
+    @api.expects(:send_state_event).with(id, 'm.room.pinned_events', { pinned: ['event'] })
     @api.set_room_pinned_events(id, ['event'])
 
-    @api.expects(:get_room_state).with(id, 'm.room.power_levels', {})
+    @api.expects(:get_room_state).with(id, 'm.room.power_levels')
     @api.get_room_power_levels(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.power_levels', { level: 1, events: {} }, {})
+    @api.expects(:send_state_event).with(id, 'm.room.power_levels', { level: 1, events: {} })
     @api.set_room_power_levels(id, level: 1)
 
-    @api.expects(:get_room_state).with(id, 'm.room.join_rules', {})
+    @api.expects(:get_room_state).with(id, 'm.room.join_rules')
     @api.get_room_join_rules(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.join_rules', { join_rule: :public }, {})
+    @api.expects(:send_state_event).with(id, 'm.room.join_rules', { join_rule: :public })
     @api.set_room_join_rules(id, :public)
 
-    @api.expects(:get_room_state).with(id, 'm.room.guest_access', {})
+    @api.expects(:get_room_state).with(id, 'm.room.guest_access')
     @api.get_room_guest_access(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.guest_access', { guest_access: :forbidden }, {})
+    @api.expects(:send_state_event).with(id, 'm.room.guest_access', { guest_access: :forbidden })
     @api.set_room_guest_access(id, :forbidden)
 
-    @api.expects(:get_room_state).with(id, 'm.room.create', {})
+    @api.expects(:get_room_state).with(id, 'm.room.create')
     @api.get_room_creation_info(id)
 
-    @api.expects(:get_room_state).with(id, 'm.room.encryption', {})
+    @api.expects(:get_room_state).with(id, 'm.room.encryption')
     @api.get_room_encryption_settings(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.encryption', { algorithm: 'm.megolm.v1.aes-sha2', rotation_period_ms: 604_800_000, rotation_period_msgs: 100 }, {})
+    @api.expects(:send_state_event).with(id, 'm.room.encryption', { algorithm: 'm.megolm.v1.aes-sha2', rotation_period_ms: 604_800_000, rotation_period_msgs: 100 })
     @api.set_room_encryption_settings(id)
 
-    @api.expects(:get_room_state).with(id, 'm.room.history_visibility', {})
+    @api.expects(:get_room_state).with(id, 'm.room.history_visibility')
     @api.get_room_history_visibility(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.history_visibility', { history_visibility: :anyone }, {})
+    @api.expects(:send_state_event).with(id, 'm.room.history_visibility', { history_visibility: :anyone })
     @api.set_room_history_visibility(id, :anyone)
 
-    @api.expects(:get_room_state).with(id, 'm.room.server_acl', {})
+    @api.expects(:get_room_state).with(id, 'm.room.server_acl')
     @api.get_room_server_acl(id)
 
-    @api.expects(:send_state_event).with(id, 'm.room.server_acl', { allow_ip_literals: false, allow: [], deny: [] }, {})
+    @api.expects(:send_state_event).with(id, 'm.room.server_acl', { allow_ip_literals: false, allow: [], deny: [] })
     @api.set_room_server_acl(id, allow: [], deny: [])
   end
 

--- a/test/api_cs_protocol_test.rb
+++ b/test/api_cs_protocol_test.rb
@@ -165,7 +165,7 @@ class ApiTest < Test::Unit::TestCase
     @api.get_room_power_levels(id)
 
     expect_message(@api, :send_state_event, id, 'm.room.power_levels', { level: 1, events: {} })
-    @api.set_room_power_levels(id, level: 1)
+    @api.set_room_power_levels(id, { level: 1 })
 
     expect_message(@api, :get_room_state, id, 'm.room.join_rules')
     @api.get_room_join_rules(id)

--- a/test/api_cs_protocol_test.rb
+++ b/test/api_cs_protocol_test.rb
@@ -152,6 +152,9 @@ class ApiTest < Test::Unit::TestCase
     @api.expects(:send_state_event).with(id, 'm.room.avatar', { url: 'Room avatar' })
     @api.set_room_avatar(id, 'Room avatar')
 
+    @api.expects(:get_room_state).with(id, 'm.room.aliases')
+    @api.get_room_aliases(id)
+
     @api.expects(:get_room_state).with(id, 'm.room.pinned_events')
     @api.get_room_pinned_events(id)
 

--- a/test/api_cs_protocol_verification_test.rb
+++ b/test/api_cs_protocol_verification_test.rb
@@ -90,10 +90,12 @@ class ApiCSVerificationTest < Test::Unit::TestCase
   end
 
   def call_api(method, args)
-    if args.size.positive? && args.last.is_a?(Hash)
-      @api.send(method, *args[0..-2], **args.last)
-    else
+    required_arguments_size = @api.method(method).parameters.select { |type, _| type == :req }.size
+
+    if args.size == required_arguments_size || !args.last.is_a?(Hash)
       @api.send(method, *args)
+    else
+      @api.send(method, *args[0..-2], **args.last)
     end
   end
 end

--- a/test/api_cs_protocol_verification_test.rb
+++ b/test/api_cs_protocol_verification_test.rb
@@ -62,7 +62,7 @@ class ApiCSVerificationTest < Test::Unit::TestCase
             true
           end.returns(response)
 
-          assert @api.send(data['method'], *request['args'].deep_symbolize_keys)
+          assert(call_api(data['method'], request['args'].deep_symbolize_keys))
           @api.unstub(:request)
         end
       end
@@ -79,13 +79,21 @@ class ApiCSVerificationTest < Test::Unit::TestCase
                end
 
         if code.to_s[0] == '2'
-          assert !@api.send(data['method'], *args).nil?
+          assert(!call_api(data['method'], args).nil?)
         else
-          assert_raises(MatrixSdk::MatrixRequestError.class_by_code(code)) { @api.send(data['method'], *args) }
+          assert_raises(MatrixSdk::MatrixRequestError.class_by_code(code)) { call_api(data['method'], args) }
         end
 
         @http.unstub(:request)
       end
+    end
+  end
+
+  def call_api(method, args)
+    if args.size.positive? && args.last.is_a?(Hash)
+      @api.send(method, *args[0..-2], **args.last)
+    else
+      @api.send(method, *args)
     end
   end
 end

--- a/test/room_test.rb
+++ b/test/room_test.rb
@@ -118,28 +118,34 @@ class RoomTest < Test::Unit::TestCase
     assert_nil tags[:'test.tag']
     assert_not_nil tags[:'example.tag']
 
-    @api.expects(:send_state_event).with(@id, 'm.room.name', { name: 'name' })
+    expect_message(@api, :send_state_event, @id, 'm.room.name', { name: 'name' })
     @room.name = 'name'
 
-    @api.expects(:send_state_event).with(@id, 'm.room.topic', { topic: 'topic' })
+    expect_message(@api, :send_state_event, @id, 'm.room.topic', { topic: 'topic' })
     @room.topic = 'topic'
 
-    @api.expects(:request).with(:put, :client_r0, '/directory/room/%23room%3Aexample.com', body: { room_id: '!room:example.com' }, query: {})
+    @api.expects(:request).with(
+      :put,
+      :client_r0,
+      '/directory/room/%23room%3Aexample.com',
+      body: { room_id: '!room:example.com' },
+      query: {}
+    )
     @room.add_alias('#room:example.com')
 
-    @api.expects(:send_state_event).with(@id, 'm.room.join_rules', { join_rule: :invite }).twice
+    expect_message(@api, :send_state_event, @id, 'm.room.join_rules', { join_rule: :invite }).twice
     @room.invite_only = true
     @room.join_rule = :invite
 
-    @api.expects(:send_state_event).with(@id, 'm.room.join_rules', { join_rule: :public }).twice
+    expect_message(@api, :send_state_event, @id, 'm.room.join_rules', { join_rule: :public }).twice
     @room.invite_only = false
     @room.join_rule = :public
 
-    @api.expects(:send_state_event).with(@id, 'm.room.guest_access', { guest_access: :can_join }).twice
+    expect_message(@api, :send_state_event, @id, 'm.room.guest_access', { guest_access: :can_join }).twice
     @room.allow_guests = true
     @room.guest_access = :can_join
 
-    @api.expects(:send_state_event).with(@id, 'm.room.guest_access', { guest_access: :forbidden }).twice
+    expect_message(@api, :send_state_event, @id, 'm.room.guest_access', { guest_access: :forbidden }).twice
     @room.allow_guests = false
     @room.guest_access = :forbidden
   end

--- a/test/room_test.rb
+++ b/test/room_test.rb
@@ -118,28 +118,28 @@ class RoomTest < Test::Unit::TestCase
     assert_nil tags[:'test.tag']
     assert_not_nil tags[:'example.tag']
 
-    @api.expects(:send_state_event).with(@id, 'm.room.name', { name: 'name' }, {})
+    @api.expects(:send_state_event).with(@id, 'm.room.name', { name: 'name' })
     @room.name = 'name'
 
-    @api.expects(:send_state_event).with(@id, 'm.room.topic', { topic: 'topic' }, {})
+    @api.expects(:send_state_event).with(@id, 'm.room.topic', { topic: 'topic' })
     @room.topic = 'topic'
 
     @api.expects(:request).with(:put, :client_r0, '/directory/room/%23room%3Aexample.com', body: { room_id: '!room:example.com' }, query: {})
     @room.add_alias('#room:example.com')
 
-    @api.expects(:send_state_event).with(@id, 'm.room.join_rules', { join_rule: :invite }, {}).twice
+    @api.expects(:send_state_event).with(@id, 'm.room.join_rules', { join_rule: :invite }).twice
     @room.invite_only = true
     @room.join_rule = :invite
 
-    @api.expects(:send_state_event).with(@id, 'm.room.join_rules', { join_rule: :public }, {}).twice
+    @api.expects(:send_state_event).with(@id, 'm.room.join_rules', { join_rule: :public }).twice
     @room.invite_only = false
     @room.join_rule = :public
 
-    @api.expects(:send_state_event).with(@id, 'm.room.guest_access', { guest_access: :can_join }, {}).twice
+    @api.expects(:send_state_event).with(@id, 'm.room.guest_access', { guest_access: :can_join }).twice
     @room.allow_guests = true
     @room.guest_access = :can_join
 
-    @api.expects(:send_state_event).with(@id, 'm.room.guest_access', { guest_access: :forbidden }, {}).twice
+    @api.expects(:send_state_event).with(@id, 'm.room.guest_access', { guest_access: :forbidden }).twice
     @room.allow_guests = false
     @room.guest_access = :forbidden
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,3 +9,11 @@ require 'matrix_sdk'
 
 require 'test/unit'
 require 'mocha/test_unit'
+
+RUBY_MAJOR_MINOR_VERSION = RUBY_VERSION[0..2].freeze
+OLDER_RUBY = %w[2.5 2.6].include?(RUBY_MAJOR_MINOR_VERSION)
+
+def expect_message(object, message, *args)
+  args = args << {} if OLDER_RUBY
+  object.expects(message).with(*args)
+end


### PR DESCRIPTION
Currently there are 2 different deprecation warnings that get thrown. Both of these warnings end up blocking using gem with Ruby 3 since `ArgumentError: wrong number of arguments` will get thrown.

These warnings are:
- `Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call"last argument as keyword parameters is deprecated`,
- `Passing the keyword argument as the last hash parameter is deprecated.`

I did also medium size refacto in api_cs_protocol_verification_test to improve it's readability and to understand the issue better, but for easier reviewing, I will PR this refacto separately.

Number of tests is the same, but there is 1 more assertions because one added assertion.

Tested with Ruby 2.5.8, 2.6.6, 2.7.2 and 3.0.0.