### PR TITLE
Room#modify_user_power_levels  converts user arguments

### DIFF
--- a/lib/matrix_sdk/room.rb
+++ b/lib/matrix_sdk/room.rb
@@ -817,8 +817,17 @@ module MatrixSdk
 
       if users
         data[:users] = {} unless data.key? :users
-        data[:users].merge!(users)
-        data[:users].delete_if { |_k, v| v.nil? }
+        users.each do |user, level|
+          user = user.id if user.is_a? User
+          user = MXID.new(user.to_s) unless user.is_a? MXID
+          raise ArgumentError, 'Must provide a valid user or MXID' unless user.user?
+
+          if level.nil?
+            data[:users].delete(user.to_s.to_sym)
+          else
+            data[:users][user.to_s.sym] = level
+          end
+        end
       end
 
       client.api.set_power_levels(id, data)


### PR DESCRIPTION
Other methods such as `Room#user_powerlevel` or `Room#invite_user` take a variety of argument types (`User`, `MXID`, `String`, `Symbol`, ...) whereas `Room#modify_user_power_levels` does not yet show the desired behaviour when passing non-Symbols. This may lead to unexpected consequences when `data[:users]` contains the same user multiple times with contradicting power levels, e.g., by passing a `String` argument.

This commit applies the same conversion procedure to the argument as is used by many other methods.