### PR TITLE
autoload all classes from errors.rb

### DIFF
--- a/lib/matrix_sdk.rb
+++ b/lib/matrix_sdk.rb
@@ -19,6 +19,11 @@ module MatrixSdk
 
   autoload :MatrixError, 'matrix_sdk/errors'
   autoload :MatrixRequestError, 'matrix_sdk/errors'
+  autoload :MatrixNotAuthorizedError, 'matrix_sdk/errors'
+  autoload :MatrixForbiddenError, 'matrix_sdk/errors'
+  autoload :MatrixNotFoundError, 'matrix_sdk/errors'
+  autoload :MatrixConflictError, 'matrix_sdk/errors'
+  autoload :MatrixTooManyRequestsError, 'matrix_sdk/errors'
   autoload :MatrixConnectionError, 'matrix_sdk/errors'
   autoload :MatrixTimeoutError, 'matrix_sdk/errors'
   autoload :MatrixUnexpectedResponseError, 'matrix_sdk/errors'


### PR DESCRIPTION
Some of the errors can not be used in a `rescue` clause since they are not loaded.