### PR TITLE
Compatibility with Ruby 3.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,10 @@ test:ruby3.0:
   extends: .test
   image: "ruby:3.0"
 
+test:ruby3.0:
+extends: .test
+image: "ruby:3.1"
+
 pages:
   image: ruby
   stage: deploy

--- a/lib/matrix_sdk/util/uri.rb
+++ b/lib/matrix_sdk/util/uri.rb
@@ -12,9 +12,15 @@ module URI
     end
   end
 
-  @@schemes['MXC'] = MXC
+  # TODO: Use +register_scheme+ on Ruby >=3.1 and fall back to old behavior
+  # for older Rubies. May be removed at EOL of Ruby 3.0.
+  if respond_to? :register_scheme
+    register_scheme 'MXC', MXC
+  else
+    @@schemes['MXC'] = MXC
+  end
 
-  unless @@schemes.key? 'MATRIX'
+  unless scheme_list.has_key? 'MATRIX'
     # A matrix: URI according to MSC2312
     class MATRIX < Generic
       attr_reader :authority, :action, :mxid, :mxid2, :via
@@ -84,6 +90,12 @@ module URI
       end
     end
 
-    @@schemes['MATRIX'] = MATRIX
+    # TODO: Use +register_scheme+ on Ruby >=3.1 and fall back to old behavior
+    # for older Rubies. May be removed at EOL of Ruby 3.0.
+    if respond_to? :register_scheme
+      register_scheme 'MATRIX', MATRIX
+    else
+      @@schemes['MXC'] = MXC
+    end
   end
 end


### PR DESCRIPTION
@ananace Three tests don't pass, however, the mileage on your CI might differ since the tests are broken for me on Ruby 3.0 and 2.7 as well. Maybe related to my stack (M1 Mac), but the gem works fine on Ruby 3.1 both when I use it locally as well as deployed to the server. Sorry for not having the time to drill down right now.