### PR TITLE
Alias MXID#to_s to #to_str to make #== commutative

### DIFF
--- a/lib/matrix_sdk/mxid.rb
+++ b/lib/matrix_sdk/mxid.rb
@@ -45,6 +45,8 @@ module MatrixSdk
       "#{sigil}#{localpart}#{homeserver_suffix}"
     end
 
+    alias_method :to_str, :to_s
+
     # Returns the type of the ID
     #
     # @return [Symbol] The MXID type, one of (:user_id, :room_id, :event_id, :group_id, or :room_alias)


### PR DESCRIPTION
Without this, `MXID == String` worked, whereas `String == MXID` didn't. The
reason for this is that `String#==` calls `#to_str` on the other object,
instead of `#to_s`.

This is reflected in the result of `Room#display_name` for direct chats, which would always return the name of the client itself as well.