### PR TITLE
room: fix `to_s`

### DIFF
--- a/lib/matrix_sdk/room.rb
+++ b/lib/matrix_sdk/room.rb
@@ -113,9 +113,8 @@ module MatrixSdk
     end
 
     def to_s
-      prefix = canonical_alias if canonical_alias_has_value?
-      prefix ||= id
-      return "#{prefix} | #{name}" if name_has_value?
+      prefix = canonical_alias || id
+      return "#{prefix} | #{name}" unless name.nil?
 
       prefix
     end


### PR DESCRIPTION
Fixing the following error when trying to print a `room`:

```
/usr/local/bundle/gems/matrix_sdk-2.8.0/lib/matrix_sdk/room.rb:116:in `to_s': undefined method `canonical_alias_has_value?' for #<MatrixSdk::Room:0x00007fde95fb13c0 ...> (NoMethodError)
                                                                                               
      prefix = canonical_alias if canonical_alias_has_value?                                                                                                                                  
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                  
Did you mean?  canonical_alias                                                                 
        from /app/main.rb:17:in `block in <top (required)>' 
        from /app/main.rb:16:in `each'                                                         
        from /app/main.rb:16:in `<top (required)>'           
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from /app/config.ru:4:in `block in <main>'                                                                                                                                            
        from /usr/local/bundle/gems/rack-2.2.7/lib/rack/builder.rb:116:in `eval'                                                                                                              
        from /usr/local/bundle/gems/rack-2.2.7/lib/rack/builder.rb:116:in `new_from_string'                                                                                                   
        from /usr/local/bundle/gems/rack-2.2.7/lib/rack/builder.rb:105:in `load_file'
        from /usr/local/bundle/gems/rack-2.2.7/lib/rack/builder.rb:66:in `parse_file'      
        from /usr/local/bundle/gems/rack-2.2.7/lib/rack/server.rb:349:in `build_app_and_options_from_config'
        from /usr/local/bundle/gems/rack-2.2.7/lib/rack/server.rb:249:in `app'       
        from /usr/local/bundle/gems/rack-2.2.7/lib/rack/server.rb:422:in `wrapped_app'                                                                                                        
        from /usr/local/bundle/gems/rack-2.2.7/lib/rack/server.rb:312:in `block in start'                                                                                                     
        from /usr/local/bundle/gems/rack-2.2.7/lib/rack/server.rb:379:in `handle_profiling'
        from /usr/local/bundle/gems/rack-2.2.7/lib/rack/server.rb:311:in `start'         
        from /usr/local/bundle/gems/rack-2.2.7/lib/rack/server.rb:168:in `start'           
        from /usr/local/bundle/gems/rack-2.2.7/bin/rackup:5:in `<top (required)>'              
        from /usr/local/bundle/bin/rackup:25:in `load'                                         
        from /usr/local/bundle/bin/rackup:25:in `<main>'
```