### PR TITLE
Fix nil error when sorting room aliases

### DIFF
--- a/lib/matrix_sdk/room.rb
+++ b/lib/matrix_sdk/room.rb
@@ -981,7 +981,7 @@ module MatrixSdk
       data = tinycache_adapter.read(:aliases) || []
       data << canonical_alias
       data += event.dig(*%i[content alt_aliases]) || []
-      tinycache_adapter.write(:aliases, data.uniq.sort)
+      tinycache_adapter.write(:aliases, data.compact.uniq.sort)
     end
 
     def room_handlers?


### PR DESCRIPTION
Under some circumstances, the array of canonical aliases may contain nil entries, which causes the sort to fail. This solution simply removes those nil entries before sorting.